### PR TITLE
Add GitHub Actions CI/CD workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,87 @@
+name: Publish to CocoaPods
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  check-release:
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if this is a release merge
+        id: check
+        run: |
+          LAST_MSG=$(git log -1 --format=%s)
+          if echo "$LAST_MSG" | grep -qE "Merge pull request.*release/"; then
+            VERSION=$(grep 's\.version' RefinerSDK.podspec | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+            echo "is_release=true" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Detected iOS release: $VERSION"
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "Not a release merge, skipping CocoaPods publish."
+          fi
+
+  publish:
+    needs: check-release
+    if: needs.check-release.outputs.is_release == 'true'
+    runs-on: macos-latest
+    env:
+      VERSION: ${{ needs.check-release.outputs.version }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Install CocoaPods
+        run: gem install cocoapods --no-document
+
+      - name: Validate podspec
+        run: pod lib lint RefinerSDK.podspec --allow-warnings
+
+      - name: Push to CocoaPods trunk
+        run: |
+          for attempt in 1 2 3; do
+            pod trunk push RefinerSDK.podspec --allow-warnings && break
+            echo "Attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Create git tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git tag "${VERSION}"
+          git push origin "${VERSION}"
+          gh release create "${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --title "${VERSION}" \
+            --notes "iOS SDK ${VERSION} published to CocoaPods and available via SPM.
+
+          **CocoaPods:**
+          \`\`\`ruby
+          pod 'RefinerSDK', '~> ${VERSION}'
+          \`\`\`
+
+          **SPM:**
+          Add \`https://github.com/refiner-io/mobile-sdk-ios\` at version \`${VERSION}\`."
+
+          echo "## Published iOS ${VERSION} to CocoaPods" >> $GITHUB_STEP_SUMMARY
+          echo "https://cocoapods.org/pods/RefinerSDK" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,151 @@
+name: Release - Prepare
+
+# Triggered by mobile-sdk-internal after iOS XCFrameworks are built and attached to a GitHub Release.
+# Downloads the XCFrameworks, bumps the podspec version, and opens a PR for review.
+
+on:
+  repository_dispatch:
+    types: [release]
+  # Manual re-trigger in case repository_dispatch fails
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "iOS SDK version (e.g. 1.8.0)"
+        required: true
+      release_tag:
+        description: "GitHub Release tag in mobile-sdk-internal to download XCFrameworks from (e.g. ios-1.8.0)"
+        required: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve inputs
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
+            echo "release_tag=${{ github.event.client_payload.release_tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "release_tag=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          # Use LFS if ever enabled — currently binaries are plain git objects
+          lfs: false
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        run: |
+          BRANCH="release/${{ steps.resolve.outputs.version }}"
+          git checkout -b "$BRANCH"
+
+      - name: Download XCFrameworks from mobile-sdk-internal release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          RELEASE_TAG="${{ steps.resolve.outputs.release_tag }}"
+
+          # Download XCFramework zips from the internal repo release
+          gh release download "$RELEASE_TAG" \
+            --repo refiner-io/mobile-sdk-internal \
+            --pattern "*.xcframework.zip" \
+            --dir /tmp/xcframeworks
+
+          ls /tmp/xcframeworks/
+
+      - name: Replace XCFrameworks
+        run: |
+          # Remove existing XCFrameworks
+          rm -rf RefinerSDK.xcframework RefinerInternalSDK.xcframework
+
+          # Unzip new ones
+          unzip -o /tmp/xcframeworks/RefinerSDK.xcframework.zip
+          unzip -o /tmp/xcframeworks/RefinerInternalSDK.xcframework.zip
+
+      - name: Bump version in RefinerSDK.podspec
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          sed -i "s/s\.version\s*=\s*\"[^\"]*\"/s.version       = \"${VERSION}\"/" RefinerSDK.podspec
+          grep "s.version" RefinerSDK.podspec
+
+      - name: Commit and push
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          BRANCH="release/${VERSION}"
+          git add RefinerSDK.xcframework RefinerInternalSDK.xcframework RefinerSDK.podspec
+          git commit -m "Release ${VERSION}"
+          git push origin "$BRANCH"
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          VERSION="${{ steps.resolve.outputs.version }}"
+          BRANCH="release/${VERSION}"
+          PR_URL=$(gh pr create \
+            --repo "${{ github.repository }}" \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release ${VERSION}" \
+            --body "$(cat <<EOF
+          # What it does
+
+          This pull request releases iOS SDK version ${VERSION} via CocoaPods and SPM.
+
+          **Changes:**
+          - Updated \`RefinerSDK.xcframework\` (new binary)
+          - Updated \`RefinerInternalSDK.xcframework\` (new binary)
+          - Bumped \`s.version\` in \`RefinerSDK.podspec\` to \`${VERSION}\`
+
+          After merging, CI will automatically:
+          1. Run \`pod lib lint RefinerSDK.podspec\`
+          2. Push to CocoaPods trunk (\`pod trunk push\`)
+          3. Create git tag \`${VERSION}\` and GitHub Release
+
+          SPM consumers will automatically resolve the new version via the git tag.
+
+          # How to test it
+
+          1. Pull this branch locally
+          2. Run \`pod lib lint RefinerSDK.podspec --allow-warnings\` to validate the podspec
+          3. Optionally integrate locally via \`path:\` in a test app to verify the XCFrameworks work
+
+          # Acceptance criteria
+
+          * \`RefinerSDK.podspec\` version is \`${VERSION}\`
+          * XCFrameworks are present and not corrupted
+          * \`pod lib lint\` passes without errors
+
+          # Link to ticket
+
+          [Add Trello link here]
+
+          ---
+          > **Before merging:** Add a comment **"Reviewed & validated"** to confirm you have reviewed and tested this release.
+          > Merging will automatically publish to CocoaPods trunk.
+          EOF
+          )")
+          echo "PR created: $PR_URL"
+          echo "## iOS Release PR" >> $GITHUB_STEP_SUMMARY
+          echo "Version: \`${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "PR: $PR_URL" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# What it does

This pull request adds GitHub Actions workflows to automate the iOS SDK release process for this distribution repository.

**Workflows added:**

- `release-prepare.yml` — Triggered via `repository_dispatch` from `mobile-sdk-internal` after XCFrameworks are built; downloads `RefinerSDK.xcframework` and `RefinerInternalSDK.xcframework` from the internal repo's GitHub Release, bumps `s.version` in `RefinerSDK.podspec`, commits everything to a `release/x.x.x` branch, and opens a PR to main. Also supports manual re-triggering via `workflow_dispatch`.
- `publish.yml` — Triggered automatically when a release PR is merged to main; runs `pod lib lint`, pushes to CocoaPods trunk (`pod trunk push`), creates the git tag, and creates a GitHub Release. Retries `pod trunk push` up to 3 times on network failures.

SPM consumers are served automatically — `Package.swift` uses local `path:` references and the new git tag points to the commit with the correct binaries.

**Required setup before these workflows can run:**
- Add `APP_ID` and `APP_PRIVATE_KEY` secrets (GitHub App for the `refiner-io` org)
- Add `COCOAPODS_TRUNK_TOKEN` secret (from `pod trunk register`)

# How to test it

1. After setting up secrets, trigger `release-prepare.yml` manually via `workflow_dispatch` with a test version and release tag
2. Verify the XCFrameworks are downloaded and committed, and the podspec version is correct
3. Run `pod lib lint RefinerSDK.podspec --allow-warnings` locally on the branch to validate
4. Close the test PR without merging

# Acceptance criteria

* Both workflow files are valid YAML
* `release-prepare.yml` correctly downloads XCFrameworks from the internal repo release
* `release-prepare.yml` correctly bumps `s.version` in `RefinerSDK.podspec`
* `publish.yml` only runs on release merge commits (not every push to main)
* `pod lib lint` passes on the generated PR branch

# Link to ticket

[Add Trello link here]